### PR TITLE
Updating Discord Webhook Embeds to Be Pretty and Start from Grip Screen

### DIFF
--- a/Config.sample.toml
+++ b/Config.sample.toml
@@ -145,12 +145,23 @@ negative = [81, 82]
 # Set USER_ID as explained here https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-
 # === WEBHOOK_ID and WEBHOOK_TOKEN ===
 # Follow the steps here: https://hackaday.com/2018/02/15/creating-a-discord-webhook-in-python/
-WEBHOOK_ID = ""
-WEBHOOK_TOKEN = ""
+WEBHOOK_ID = "PLACE_ID_WITHIN_QUOTES"
+WEBHOOK_TOKEN = "PLACE_TOKEN_WITHIN_QUOTES"
 # === USER_ID ===
 # This is your Discord User ID for mentioning you.
 # More info: https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-
-USER_ID = ""
+USER_ID = "PLACE_ID_WITHIN_QUOTES"
+# === USER_SHORT_NAME ===
+# To personalize your messages, please include a name for the webhooks to use.
+# Could be your actual name.
+USER_SHORT_NAME = "YOUR_SHORT_NAME_WITHIN_QUOTES"
+# === UPDATE_LEVELS ===
+# There are multiple types of levels that can be sent via the Discord Webhook to inform
+# your progress,
+#   "all" - provides all possible updates to your webhook, includes stats after a completed run
+#   "only_shiny" - will only push updates if shinies are found
+#   "none" - ignores all discord messages
+UPDATE_LEVELS = "all"
 
 # ==========
 # === LANGUAGE SETTINGS

--- a/README.md
+++ b/README.md
@@ -143,3 +143,7 @@ AutoMaxLair was initially written by [ercdndrs](https://github.com/ercdndrs). It
 * Improved config file
 * Improved stats checking
 * More improvements on the way!
+
+## Acknowledgements
+
+Thanks to [pokemondb.net](https://pokemondb.net/) for hosting the sprites of the bosses.

--- a/auto_max_lair.py
+++ b/auto_max_lair.py
@@ -43,8 +43,19 @@ ENABLE_DEBUG_LOGS = config['advanced']['ENABLE_DEBUG_LOGS']
 LOG_NAME = f"{BOSS}_{datetime.now().strftime('%Y-%m-%d %H-%M-%S')}"
 
 
-def initialize(__) -> str:
+def initialize(ctrlr) -> str:
     """Placeholder. Immediately enter the join stage."""
+    # send a discord message that we're ready to rumble
+    ctrlr.send_discord_message(False, f"Starting a new full run for {ctrlr.boss}!",
+        embed_fields=ctrlr.get_stats_for_discord(), level="update"
+    )
+
+    # assume we're starting from the select controller menu, connect, then
+    # press home twice to return to the game
+    ctrlr.push_buttons(
+        (b'a', 2), (b'h', 2.0), (b'h', 2.0)
+    )
+
     return 'join'
 
 
@@ -509,6 +520,13 @@ def select_pokemon(ctrlr) -> str:
         ctrlr.reset_run()
         ctrlr.record_ore_reward()
         ctrlr.log('Preparing for another run.')
+
+        ctrlr.send_discord_message(
+            False,
+            "No Pokémon were caught in the last run.",
+            embed_fields=ctrlr.get_stats_for_discord(),
+            level="update"
+        )
         # No Pokemon to review, so go back to the beginning.
         # Note that the "keep path" mode is meant to be used on a good path, so
         # although the path would be lost that situation should never arise.
@@ -517,9 +535,12 @@ def select_pokemon(ctrlr) -> str:
     elif run.num_caught == 4 and ctrlr.mode == 'find path':
         ctrlr.display_results(screenshot=True)
         ctrlr.send_discord_message(
-            True, f'Found a winning path for {run.caught_pokemon[3]} with '
-            f'{run.lives} lives remaining!',
-            f'logs/{ctrlr.log_name}_cap_{ctrlr.num_saved_images}.png')
+            False, 
+            f"Found a winning path for {ctrlr.boss} with {run.lives} remaining.",
+            path_to_picture=f'logs/{ctrlr.log_name}_cap_{ctrlr.num_saved_images}.png',
+            embed_fields=ctrlr.get_stats_for_discord(),
+            level="update"
+        )
         ctrlr.log(f'This path won with {run.lives} lives remaining.')
         return None  # Return None to signal the program to end.
 
@@ -543,8 +564,11 @@ def select_pokemon(ctrlr) -> str:
             ctrlr.log('******************************')
             ctrlr.display_results(screenshot=True)
             ctrlr.send_discord_message(
-                True, f'Matching stats found for {run.caught_pokemon[3]}!',
-                f'logs/{ctrlr.log_name}_cap_{ctrlr.num_saved_images}.png')
+                True, f"Matching stats found for {ctrlr.boss}!",
+                path_to_picture=f'logs/{ctrlr.log_name}_cap_{ctrlr.num_saved_images}.png',
+                embed_fields=ctrlr.get_stats_for_discord(),
+                level="shiny"
+            )
             return None  # End whenever a matching stats legendary is found
 
         ctrlr.push_button(b'<', 1)
@@ -571,22 +595,29 @@ def select_pokemon(ctrlr) -> str:
                 f'Shiny {run.caught_pokemon[run.num_caught - 1 - i]} will be '
                 'kept.'
             )
+            ctrlr.log("Adding information to the number of found shinies", "DEBUG")
             ctrlr.caught_shinies.append(
                 run.caught_pokemon[run.num_caught - 1 - i]
             )
             ctrlr.shinies_found += 1
+            ctrlr.log("Sending off to save a screenshot", "DEBUG")
             ctrlr.display_results(screenshot=True)
             ctrlr.push_buttons((b'p', 1), (b'b', 3), (b'p', 1))
             if run.num_caught == 4 and i == 0:
                 ctrlr.send_discord_message(
                     True, f'Found a shiny {run.caught_pokemon[3]}!',
-                    f'logs/{ctrlr.log_name}_cap_{ctrlr.num_saved_images}.png')
+                    path_to_picture=f'logs/{ctrlr.log_name}_cap_{ctrlr.num_saved_images}.png',
+                    embed_fields=ctrlr.get_stats_for_discord(increment_one=True),
+                    level="shiny"
+                )
                 return None  # End whenever a shiny legendary is found.
             else:
                 ctrlr.send_discord_message(
-                    False, f'Found a shiny '
-                    f'{run.caught_pokemon[run.num_caught - 1 - i]}!',
-                    f'logs/{ctrlr.log_name}_cap_{ctrlr.num_saved_images}.png')
+                    False, f'Found a shiny {run.caught_pokemon[run.num_caught - 1 - i]}!',
+                    path_to_picture=f'logs/{ctrlr.log_name}_cap_{ctrlr.num_saved_images}.png',
+                    embed_fields=ctrlr.get_stats_for_discord(),
+                    level="shiny"
+                )
                 take_pokemon = True
                 break
         elif i < run.num_caught - 1:
@@ -635,9 +666,19 @@ def select_pokemon(ctrlr) -> str:
     # Start another run if there are sufficient Poke balls to do so.
     if ctrlr.check_sufficient_balls():
         ctrlr.log('Preparing for another run.')
+        ctrlr.send_discord_message(
+            False, f'Preparing for another run.',
+            embed_fields=ctrlr.get_stats_for_discord(),
+            level="update"
+        )
         return 'join'
     else:
         ctrlr.log('Out of balls. Quitting.')
+        ctrlr.send_discord_message(
+            True, f'You ran out of legendary balls! The program has exited!',
+            embed_fields=ctrlr.get_stats_for_discord(),
+            level="critical"
+        )
         return None  # Return None to signal the program to end.
 
 

--- a/auto_max_lair.py
+++ b/auto_max_lair.py
@@ -134,7 +134,7 @@ def path(ctrlr) -> str:
     # Then, move the cursor onto that boss and select it.
     for __ in range(offset):
         ctrlr.push_button(b'>', 1)
-    ctrlr.push_buttons((b'a', 4))
+    ctrlr.push_button(b'a', 4 + VIDEO_EXTRA_DELAY)
     run.advance_node()
     ctrlr.log(
         f'Chose path with index {offset} from the left, towards type '
@@ -433,7 +433,7 @@ def backpacker(ctrlr) -> str:
 
     # Note: a long delay is required here so the bot doesn't think a battle
     # started.
-    ctrlr.push_button(b'a', 7)
+    ctrlr.push_button(b'a', 7 + VIDEO_EXTRA_DELAY)
 
     ctrlr.log('Finished choosing an item.', 'DEBUG')
     return 'detect'
@@ -481,13 +481,13 @@ def scientist(ctrlr) -> str:
     if run.pokemon is None or average_score > existing_score:
         # Note: a long delay is required here so the bot doesn't think a
         # battle started.
-        ctrlr.push_buttons((None, 3), (b'a', 7))
+        ctrlr.push_buttons((None, 3), (b'a', 7 + VIDEO_EXTRA_DELAY))
         run.pokemon = None
         ctrlr.log('Took a Pokemon from the scientist.')
     else:
         # Note: a long delay is required here so the bot doesn't think a
         # battle started.
-        ctrlr.push_buttons((None, 3), (b'b', 7))
+        ctrlr.push_buttons((None, 3), (b'b', 7 + VIDEO_EXTRA_DELAY))
         ctrlr.log(f'Decided to keep going with {run.pokemon.name_id}')
     return 'detect'
 

--- a/auto_max_lair.py
+++ b/auto_max_lair.py
@@ -53,7 +53,7 @@ def initialize(ctrlr) -> str:
     # assume we're starting from the select controller menu, connect, then
     # press home twice to return to the game
     ctrlr.push_buttons(
-        (b'a', 2), (b'h', 2.0), (b'h', 2.0)
+        (b'a', 2), (b'h', 2.0), (b'h', 2.0), (b'b', 1.5), (b'b', 1.5)
     )
 
     return 'join'

--- a/auto_max_lair.py
+++ b/auto_max_lair.py
@@ -607,7 +607,7 @@ def select_pokemon(ctrlr) -> str:
                 ctrlr.send_discord_message(
                     True, f'Found a shiny {run.caught_pokemon[3]}!',
                     path_to_picture=f'logs/{ctrlr.log_name}_cap_{ctrlr.num_saved_images}.png',
-                    embed_fields=ctrlr.get_stats_for_discord(increment_one=True),
+                    embed_fields=ctrlr.get_stats_for_discord(),
                     level="shiny"
                 )
                 return None  # End whenever a shiny legendary is found.

--- a/automaxlair/da_controller.py
+++ b/automaxlair/da_controller.py
@@ -765,3 +765,28 @@ class DAController(SwitchController):
             image=self.get_frame(
                 rectangle_set=self.stage, resize=True), log=log,
             screenshot=screenshot)
+        
+    def get_stats_for_discord(self, increment_one=False) -> dict:
+        """This method takes information from the run and returns a nice dictionary
+        for embedding to Discord"""
+
+
+        the_dict = {
+            "Boss": self.boss,
+            "Runs": self.runs,
+            "Wins": self.wins,
+            "Mode": self.mode,
+            "Base Balls": self.base_balls,
+            "Legendary Balls": self.legendary_balls,
+            "Dynite Ore": self.dynite_ore,
+            "Shinies Found": self.shinies_found
+        }
+
+        # if we have to increment one, we need to adjust the final stats!
+        if increment_one:
+            the_dict["Runs"] += 1
+            the_dict["Wins"] += 1
+            the_dict["Legendary Balls"] -= 1
+            the_dict["Base Balls"] -= 1
+        
+        return the_dict

--- a/automaxlair/da_controller.py
+++ b/automaxlair/da_controller.py
@@ -766,27 +766,23 @@ class DAController(SwitchController):
                 rectangle_set=self.stage, resize=True), log=log,
             screenshot=screenshot)
         
-    def get_stats_for_discord(self, increment_one=False) -> dict:
+    def get_stats_for_discord(self) -> dict:
         """This method takes information from the run and returns a nice dictionary
-        for embedding to Discord"""
-
+        for embedding to Discord
+        
+        increment_one is only for a win with a shiny, so that we can get the nice
+        status screen with the screenshot.
+        """
 
         the_dict = {
             "Boss": self.boss,
-            "Runs": self.runs,
-            "Wins": self.wins,
-            "Mode": self.mode,
+            "Wins/Runs": f"{self.wins}/{self.runs}",
             "Base Balls": self.base_balls,
             "Legendary Balls": self.legendary_balls,
             "Dynite Ore": self.dynite_ore,
-            "Shinies Found": self.shinies_found
         }
 
-        # if we have to increment one, we need to adjust the final stats!
-        if increment_one:
-            the_dict["Runs"] += 1
-            the_dict["Wins"] += 1
-            the_dict["Legendary Balls"] -= 1
-            the_dict["Base Balls"] -= 1
+        if self.shinies_found > 0:
+            the_dict["Shinies Found"] = self.shinies_found
         
         return the_dict

--- a/automaxlair/switch_controller.py
+++ b/automaxlair/switch_controller.py
@@ -425,7 +425,8 @@ class SwitchController:
         # construct the webhook object
         webhook = discord.Webhook.partial(
             self.webhook_id, self.webhook_token,
-            adapter=discord.RequestsWebhookAdapter()
+            adapter=discord.RequestsWebhookAdapter(),
+            timestamp=datetime.utcnow()
         )
 
         # then build up our embed object

--- a/automaxlair/switch_controller.py
+++ b/automaxlair/switch_controller.py
@@ -455,7 +455,10 @@ class SwitchController:
             my_file = None
         
         # Open the image to be sent.
-        webhook.send(send_str, embed=embed, file=my_file)
+        try:
+            webhook.send(send_str, embed=embed, file=my_file)
+        except Exception as e:
+            self.log("The Discord webhook failed to send: " + str(e), "ERROR")
 
 
 class VideoCaptureHelper:

--- a/automaxlair/switch_controller.py
+++ b/automaxlair/switch_controller.py
@@ -432,9 +432,9 @@ class SwitchController:
         embed = discord.Embed(
             title="AutoMaxLair Update", 
             colour=self.discord_embed_color,
-            thumbnail=f"https://img.pokemondb.net/sprites/home/shiny/{self.boss}.png"
             )
 
+        embed.set_thumbnail(url=f"https://img.pokemondb.net/sprites/home/shiny/{self.boss}.png")
         embed.set_footer(text="AutoMaxLair")
 
         # if we have fields that we want to add, we can!

--- a/automaxlair/switch_controller.py
+++ b/automaxlair/switch_controller.py
@@ -50,6 +50,9 @@ class SwitchController:
         self.webhook_id = config['discord']['WEBHOOK_ID']
         self.webhook_token = config['discord']['WEBHOOK_TOKEN']
         self.user_id = config['discord']['USER_ID']
+        self.user_nickname = config['discord'].get('USER_SHORT_NAME', "")
+        self.discord_level = config['discord'].get('UPDATE_LEVELS', "none")
+        self.discord_embed_color = discord.Color.random()
 
         self.actions = actions
         self.info = {}  # To be overwritten later.
@@ -377,9 +380,39 @@ class SwitchController:
             cv2.imshow(self.window_name, frame)
 
     def send_discord_message(
-        self, ping_yourself: bool, text: str, path_to_picture: str = None
-    ) -> None:
-        """Send a notification via Discord."""
+        self, ping_yourself: bool, text: str, path_to_picture: str = None,
+        embed_fields: dict = None, level: str = "update") -> None:
+        """Send a notification via Discord.
+        
+        Parameters
+        ----------
+        ping_yourself : bool
+            This input controls if you want to send a ping to the user in the
+            settings.
+        text : str
+            The basic text string to send to the webhook, not included in
+            the embed.
+        path_to_picture : str, optional
+            The path to the picture that should be uploaded and thrown inside
+            the embed object.
+        embed_fields : dict, optional
+            Fields to add to the embed object, should be a dictionary
+            where the keys are the titles to give and the items are the text
+            for that field.
+        level : str, optional
+            What type of update this is. Currently accepts "update", "shiny", and
+            "critical", which helps the program determine if it should send based
+            on settings provided by the user.
+        """
+
+        if self.discord_level == 'none':
+            # if they don't want discord information, just return and pass by
+            return
+        elif self.discord_level == 'only_shiny' and level == "update":
+            # if they don't want the discord update information, we can also
+            # return
+            return
+
         # Do nothing if user did not setup the Discord information.
         if self.webhook_id == '' or self.webhook_token == '' or (
             self.user_id == '' and ping_yourself
@@ -389,25 +422,40 @@ class SwitchController:
                 'ping feature.', 'DEBUG')
             return
 
-        # Create a webhook where the message can be sent to.
+        # construct the webhook object
         webhook = discord.Webhook.partial(
             self.webhook_id, self.webhook_token,
-            adapter=discord.RequestsWebhookAdapter())
+            adapter=discord.RequestsWebhookAdapter()
+        )
 
-        # Send the message with optional ping.
-        ping_str = ''
-        if ping_yourself:
-            ping_str = f'<@{self.user_id}>: '
-        
-        send_str = f'{ping_str}{text}'
-        
-        # Open the image to be sent.
+        # then build up our embed object
+        embed = discord.Embed(
+            title="AutoMaxLair Update", 
+            colour=self.discord_embed_color,
+            thumbnail=f"https://img.pokemondb.net/sprites/home/shiny/{self.boss}.png"
+            )
+
+        embed.set_footer(text="AutoMaxLair")
+
+        # if we have fields that we want to add, we can!
+        if embed_fields:
+            for name, item in embed_fields.items():
+                embed.add_field(name=name, value=item, inline=True)
+
+        # construct the proper string
+        send_str = f"<@{self.user_id}>" if ping_yourself else f'{self.user_nickname}'
+        send_str += f': {text}'
+
+        # add the image to the embed if it was included
         if path_to_picture is not None:
             with open(file=f'{path_to_picture}', mode='rb') as f:
-                my_file = discord.File(f)
-            webhook.send(send_str, file=my_file)
+                my_file = discord.File(f, filename="image.png")
+            embed.set_image(url="attachment://image.png")
         else:
-            webhook.send(send_str)
+            my_file = None
+        
+        # Open the image to be sent.
+        webhook.send(send_str, embed=embed, file=my_file)
 
 
 class VideoCaptureHelper:


### PR DESCRIPTION
This PR is a minor feature update that provides much nicer Discord information to users. There's also the ability to set the types of messages you want to receive from Discord.

I also added a sequence to the initialize function to press A, then home, then home so that users can and should start at the change grip screen. Should make sure people don't have joy-con or pro controllers connected.