### PR TITLE
Hunt NonLegends

### DIFF
--- a/Config.sample.toml
+++ b/Config.sample.toml
@@ -114,6 +114,12 @@ DYNITE_ORE = 0
 # an adventure, set this number to how many you previously had.
 CONSECUTIVE_RESETS = 0
 
+# === NON_LEGEND ==
+# This setting will reset any completed run in which the pokemon listed was caught in. It will 
+# continue to reset and use ore in this manner until it either finds a shiny of some type or 
+# does not have enough ore to afford another reset.
+NON_LEGEND = "default"
+
 # === MAXIMUM_ORE_COST ===
 # The maximum ore cost you're willing to pay in order to reset once.
 MAXIMUM_ORE_COST = 10

--- a/auto_max_lair.py
+++ b/auto_max_lair.py
@@ -40,6 +40,7 @@ BOSS = config['BOSS'].lower().replace(' ', '-')
 BOSS_INDEX = config['advanced']['BOSS_INDEX']
 pytesseract.pytesseract.tesseract_cmd = config['TESSERACT_PATH']
 ENABLE_DEBUG_LOGS = config['advanced']['ENABLE_DEBUG_LOGS']
+NON_LEGEND = config['advanced']['NON_LEGEND'].lower().replace(' ', '-')
 
 # Set the log name
 LOG_NAME = f"{BOSS}_{datetime.now().strftime('%Y-%m-%d %H-%M-%S')}"
@@ -693,6 +694,15 @@ def select_pokemon(ctrlr) -> str:
     ):
         reset_game = True
 
+    if (
+        not take_pokemon and NON_LEGEND in run.caught_pokemon
+        and ctrlr.check_sufficient_ore(1)
+    ):
+        reset_game = True
+        ctrlr.log('----------------------------------')
+        ctrlr.log(f'--Found {NON_LEGEND} on this path.--')
+        ctrlr.log('----------------------------------')
+        
     # After checking all the Pokemon, wrap up the run (including taking a
     # Pokemon or resetting the game, where appropriate).
     if not reset_game:

--- a/auto_max_lair.py
+++ b/auto_max_lair.py
@@ -702,7 +702,7 @@ def select_pokemon(ctrlr) -> str:
         ctrlr.log('----------------------------------')
         ctrlr.log(f'--Found {NON_LEGEND} on this path.--')
         ctrlr.log('----------------------------------')
-        
+
     # After checking all the Pokemon, wrap up the run (including taking a
     # Pokemon or resetting the game, where appropriate).
     if not reset_game:


### PR DESCRIPTION
Added the ability to force resets when a particular nonlegend is caught along a path. This will increase the likeliness of finding pokemon like Kanto weezing, Alolan Marowak, Alolan Raichu, etc.