### PR TITLE
Improve the UI and small fixs

### DIFF
--- a/AutoMaxLairUI - Code/AutoMaxLair.Designer.cs
+++ b/AutoMaxLairUI - Code/AutoMaxLair.Designer.cs
@@ -552,32 +552,6 @@ namespace AutoDA
             this.boxLegendBall.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.boxLegendBall.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(250)))), ((int)(((byte)(63)))), ((int)(((byte)(82)))));
             this.boxLegendBall.FormattingEnabled = true;
-            this.boxLegendBall.Items.AddRange(new object[] {
-            "Poke",
-            "Premier",
-            "Beast",
-            "Great",
-            "Ultra",
-            "Master",
-            "Friend",
-            "Lure",
-            "Quick",
-            "Repeat",
-            "Luxury",
-            "Net",
-            "Heal",
-            "Nest",
-            "Moon",
-            "Dream",
-            "Dive",
-            "Level",
-            "Love",
-            "Heavy",
-            "Dusk",
-            "Timer",
-            "Fast",
-            "Safari",
-            "Sport"});
             this.boxLegendBall.Location = new System.Drawing.Point(112, 71);
             this.boxLegendBall.Name = "boxLegendBall";
             this.boxLegendBall.Size = new System.Drawing.Size(113, 25);
@@ -590,32 +564,6 @@ namespace AutoDA
             this.boxBaseBall.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.boxBaseBall.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(250)))), ((int)(((byte)(63)))), ((int)(((byte)(82)))));
             this.boxBaseBall.FormattingEnabled = true;
-            this.boxBaseBall.Items.AddRange(new object[] {
-            "Poke",
-            "Premier",
-            "Beast",
-            "Great",
-            "Ultra",
-            "Master",
-            "Friend",
-            "Lure",
-            "Quick",
-            "Repeat",
-            "Luxury",
-            "Net",
-            "Heal",
-            "Nest",
-            "Moon",
-            "Dream",
-            "Dive",
-            "Level",
-            "Love",
-            "Heavy",
-            "Dusk",
-            "Timer",
-            "Fast",
-            "Safari",
-            "Sport"});
             this.boxBaseBall.Location = new System.Drawing.Point(112, 40);
             this.boxBaseBall.Name = "boxBaseBall";
             this.boxBaseBall.Size = new System.Drawing.Size(113, 25);
@@ -628,54 +576,6 @@ namespace AutoDA
             this.boxPokemon.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.boxPokemon.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(250)))), ((int)(((byte)(63)))), ((int)(((byte)(82)))));
             this.boxPokemon.FormattingEnabled = true;
-            this.boxPokemon.Items.AddRange(new object[] {
-            "Articuno",
-            "Zapdos",
-            "Moltres",
-            "Mewtwo",
-            "Raikou",
-            "Entei",
-            "Suicune",
-            "Lugia",
-            "Ho-Oh",
-            "Latias",
-            "Latios",
-            "Kyogre",
-            "Groudon",
-            "Rayquaza",
-            "Uxie",
-            "Mesprit",
-            "Azelf",
-            "Dialga",
-            "Palkia",
-            "Heatran",
-            "Giratina",
-            "Cresselia",
-            "Tornadus",
-            "Thundurus",
-            "Landorus",
-            "Reshiram",
-            "Zekrom",
-            "Kyurem",
-            "Xerneas",
-            "Yveltal",
-            "Zygarde",
-            "Tapu-Koko",
-            "Tapu-Lele",
-            "Tapu-Bulu",
-            "Tapu-Fini",
-            "Solgaleo",
-            "Lunala",
-            "Necrozma",
-            "Nihilego",
-            "Xerkitree",
-            "Buzzwole",
-            "Pheromosa",
-            "Celesteela",
-            "Kartana",
-            "Guzzlord",
-            "Stakataka",
-            "Blacephalon"});
             this.boxPokemon.Location = new System.Drawing.Point(112, 9);
             this.boxPokemon.Name = "boxPokemon";
             this.boxPokemon.Size = new System.Drawing.Size(113, 25);

--- a/AutoMaxLairUI - Code/AutoMaxLair.Designer.cs
+++ b/AutoMaxLairUI - Code/AutoMaxLair.Designer.cs
@@ -185,7 +185,6 @@ namespace AutoDA
             this.boxMaxDynite.TabIndex = 21;
             this.boxMaxDynite.Text = "0";
             this.boxMaxDynite.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.toolTip.SetToolTip(this.boxMaxDynite, "The maximum amount of Dynite Ore the program\r\nshall use.");
             // 
             // boxBossIndex
             // 
@@ -202,7 +201,6 @@ namespace AutoDA
             this.boxBossIndex.Size = new System.Drawing.Size(95, 25);
             this.boxBossIndex.TabIndex = 20;
             this.boxBossIndex.Text = "Top";
-            this.toolTip.SetToolTip(this.boxBossIndex, "The position of the legendary Pokémon you are hunting on the menu.");
             // 
             // boxConsecutiveResets
             // 
@@ -215,8 +213,6 @@ namespace AutoDA
             this.boxConsecutiveResets.TabIndex = 17;
             this.boxConsecutiveResets.Text = "0";
             this.boxConsecutiveResets.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.toolTip.SetToolTip(this.boxConsecutiveResets, "If you had to stop the script and have not reset your reset counter by \r\nclearing" +
-        " an adventure, set this number to how many you previously had.");
             // 
             // boxDyniteOre
             // 
@@ -229,7 +225,6 @@ namespace AutoDA
             this.boxDyniteOre.TabIndex = 19;
             this.boxDyniteOre.Text = "0";
             this.boxDyniteOre.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.toolTip.SetToolTip(this.boxDyniteOre, "The amount of Dynite Ore the program can use or \r\nyou want to recover.");
             // 
             // boxVideoDelay
             // 
@@ -242,7 +237,6 @@ namespace AutoDA
             this.boxVideoDelay.TabIndex = 18;
             this.boxVideoDelay.Text = "0.0";
             this.boxVideoDelay.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.toolTip.SetToolTip(this.boxVideoDelay, resources.GetString("boxVideoDelay.ToolTip"));
             // 
             // boxVideoScale
             // 
@@ -255,8 +249,6 @@ namespace AutoDA
             this.boxVideoScale.TabIndex = 17;
             this.boxVideoScale.Text = "0.5";
             this.boxVideoScale.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.toolTip.SetToolTip(this.boxVideoScale, "The scaling for the live display of the script.\r\nSet to less than 1 if you want t" +
-        "he image smaller than the default size.\r\n(1920x1080)");
             // 
             // checkBoxDebugLogs
             // 
@@ -268,9 +260,6 @@ namespace AutoDA
             this.checkBoxDebugLogs.Size = new System.Drawing.Size(146, 23);
             this.checkBoxDebugLogs.TabIndex = 14;
             this.checkBoxDebugLogs.Text = "Enable Debug Logs";
-            this.toolTip.SetToolTip(this.checkBoxDebugLogs, "This enables the debug logs in your Python console. This can be very useful when " +
-        "you are \r\nrunning into problems and need to report to the developers what\'s happ" +
-        "ening.");
             this.checkBoxDebugLogs.UseVisualStyleBackColor = true;
             // 
             // labelConsecutiveResets
@@ -375,8 +364,6 @@ namespace AutoDA
             this.btnTesseract.Size = new System.Drawing.Size(28, 26);
             this.btnTesseract.TabIndex = 25;
             this.btnTesseract.Text = "v";
-            this.toolTip.SetToolTip(this.btnTesseract, "This is the path to the Tesseract executable. \r\n(NOT pytesseract) \r\nOn Windows it" +
-        " is most likely inside Program Files\\\\Tesseract-OCR.");
             this.btnTesseract.UseVisualStyleBackColor = false;
             this.btnTesseract.Click += new System.EventHandler(this.btnTesseract_Click);
             // 
@@ -397,7 +384,6 @@ namespace AutoDA
             this.boxGameLanguage.Size = new System.Drawing.Size(121, 25);
             this.boxGameLanguage.TabIndex = 24;
             this.boxGameLanguage.Text = "English";
-            this.toolTip.SetToolTip(this.boxGameLanguage, "This is the language of the game you are playing.");
             this.boxGameLanguage.SelectedIndexChanged += new System.EventHandler(this.boxGameLanguage_SelectedIndexChanged);
             // 
             // labelGameLanguage
@@ -422,8 +408,6 @@ namespace AutoDA
             this.boxTesseract.TabIndex = 22;
             this.boxTesseract.Text = "C:\\\\Program Files\\\\Tesseract-OCR\\\\tesseract.exe";
             this.boxTesseract.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.toolTip.SetToolTip(this.boxTesseract, "This is the path to the Tesseract executable. \r\n(NOT pytesseract) \r\nOn Windows it" +
-        " is most likely inside Program Files\\\\Tesseract-OCR.");
             this.boxTesseract.TextChanged += new System.EventHandler(this.boxTesseract_TextChanged);
             // 
             // labelTessaract
@@ -448,7 +432,6 @@ namespace AutoDA
             this.boxLegendBallValue.TabIndex = 18;
             this.boxLegendBallValue.Text = "99";
             this.boxLegendBallValue.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.toolTip.SetToolTip(this.boxLegendBallValue, "The amount of the selected Pokéballs you have.");
             // 
             // boxVideoCapture
             // 
@@ -472,7 +455,6 @@ namespace AutoDA
             this.boxBaseBallValue.TabIndex = 17;
             this.boxBaseBallValue.Text = "99";
             this.boxBaseBallValue.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.toolTip.SetToolTip(this.boxBaseBallValue, "The amount of the selected Pokéballs you have.");
             // 
             // boxComPort
             // 
@@ -485,8 +467,6 @@ namespace AutoDA
             this.boxComPort.TabIndex = 15;
             this.boxComPort.Text = "COM4";
             this.boxComPort.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.toolTip.SetToolTip(this.boxComPort, "ComPort is for the internally connection of the serial connection. \r\nOn Windows i" +
-        "t will be of the form \"COMX\" where X is some number.");
             // 
             // boxMode
             // 
@@ -505,7 +485,6 @@ namespace AutoDA
             this.boxMode.Size = new System.Drawing.Size(113, 25);
             this.boxMode.TabIndex = 14;
             this.boxMode.Text = "Default";
-            this.toolTip.SetToolTip(this.boxMode, resources.GetString("boxMode.ToolTip"));
             // 
             // labelVideoIndex
             // 
@@ -604,8 +583,6 @@ namespace AutoDA
             this.boxLegendBall.Size = new System.Drawing.Size(113, 25);
             this.boxLegendBall.TabIndex = 7;
             this.boxLegendBall.Text = "Premier";
-            this.toolTip.SetToolTip(this.boxLegendBall, "This is the Pokéball for the legendary Pokémon. \r\nWith the \"Default\" option it wi" +
-        "ll use the first Pokéball in your inventory.");
             // 
             // boxBaseBall
             // 
@@ -644,8 +621,6 @@ namespace AutoDA
             this.boxBaseBall.Size = new System.Drawing.Size(113, 25);
             this.boxBaseBall.TabIndex = 6;
             this.boxBaseBall.Text = "Premier";
-            this.toolTip.SetToolTip(this.boxBaseBall, "This is the Pokéball that you use for non legendary Pokémon. \r\nWith the \"Default\"" +
-        " option it will use the first Pokéball in your inventory.");
             // 
             // boxPokemon
             // 
@@ -706,7 +681,6 @@ namespace AutoDA
             this.boxPokemon.Size = new System.Drawing.Size(113, 25);
             this.boxPokemon.TabIndex = 5;
             this.boxPokemon.Text = "Articuno";
-            this.toolTip.SetToolTip(this.boxPokemon, "This is the legendary you are resetting for.");
             // 
             // btnSetting
             // 
@@ -915,7 +889,6 @@ namespace AutoDA
             this.boxPingSettings.Size = new System.Drawing.Size(151, 25);
             this.boxPingSettings.TabIndex = 21;
             this.boxPingSettings.Text = "none";
-            this.toolTip.SetToolTip(this.boxPingSettings, resources.GetString("boxPingSettings.ToolTip"));
             // 
             // boxPingName
             // 
@@ -928,7 +901,6 @@ namespace AutoDA
             this.boxPingName.TabIndex = 20;
             this.boxPingName.Text = "ShinyHunter";
             this.boxPingName.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.toolTip.SetToolTip(this.boxPingName, "A name that the webhook will mention.");
             // 
             // boxUserID
             // 
@@ -941,7 +913,6 @@ namespace AutoDA
             this.boxUserID.TabIndex = 19;
             this.boxUserID.Text = "123456789987654321";
             this.boxUserID.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.toolTip.SetToolTip(this.boxUserID, "Your User ID in discord.");
             // 
             // boxWebhookToken
             // 
@@ -954,7 +925,6 @@ namespace AutoDA
             this.boxWebhookToken.TabIndex = 18;
             this.boxWebhookToken.Text = "123456789987654321";
             this.boxWebhookToken.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.toolTip.SetToolTip(this.boxWebhookToken, "The Webhook Token to setup the webhook.");
             // 
             // boxWebhookID
             // 
@@ -967,7 +937,6 @@ namespace AutoDA
             this.boxWebhookID.TabIndex = 17;
             this.boxWebhookID.Text = "123456789987654321";
             this.boxWebhookID.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.toolTip.SetToolTip(this.boxWebhookID, "The Webhook ID to setup the webhook.");
             // 
             // labelMessages
             // 
@@ -1096,7 +1065,6 @@ namespace AutoDA
             this.boxCheckSpeed.Size = new System.Drawing.Size(134, 23);
             this.boxCheckSpeed.TabIndex = 28;
             this.boxCheckSpeed.Text = "Check Speed Stat";
-            this.toolTip.SetToolTip(this.boxCheckSpeed, "This enables to search for a pokémon with specific speed stats.");
             this.boxCheckSpeed.UseVisualStyleBackColor = true;
             // 
             // boxCheckAttack
@@ -1109,7 +1077,6 @@ namespace AutoDA
             this.boxCheckAttack.Size = new System.Drawing.Size(136, 23);
             this.boxCheckAttack.TabIndex = 27;
             this.boxCheckAttack.Text = "Check Attack Stat";
-            this.toolTip.SetToolTip(this.boxCheckAttack, "This enables to search for a pokémon with specific attack stats.");
             this.boxCheckAttack.UseVisualStyleBackColor = true;
             // 
             // boxSpeedNeg
@@ -1123,8 +1090,6 @@ namespace AutoDA
             this.boxSpeedNeg.TabIndex = 26;
             this.boxSpeedNeg.Text = "81";
             this.boxSpeedNeg.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.toolTip.SetToolTip(this.boxSpeedNeg, "Enter the values for Speed Stats you want to search for, \r\nwhen the legendary has" +
-        " a negetive nature.\r\n");
             // 
             // boxSpeedNeut
             // 
@@ -1137,8 +1102,6 @@ namespace AutoDA
             this.boxSpeedNeut.TabIndex = 25;
             this.boxSpeedNeut.Text = "90";
             this.boxSpeedNeut.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.toolTip.SetToolTip(this.boxSpeedNeut, "Enter the values for Speed Stats you want to search for, \r\nwhen the legendary has" +
-        " a neutral nature.\r\n");
             // 
             // labelSpeedNeg
             // 
@@ -1212,8 +1175,6 @@ namespace AutoDA
             this.boxSpeedPos.TabIndex = 17;
             this.boxSpeedPos.Text = "99";
             this.boxSpeedPos.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.toolTip.SetToolTip(this.boxSpeedPos, "Enter the values for Speed Stats you want to search for, \r\nwhen the legendary has" +
-        " a positive nature.");
             // 
             // boxAttackNeg
             // 
@@ -1226,8 +1187,6 @@ namespace AutoDA
             this.boxAttackNeg.TabIndex = 19;
             this.boxAttackNeg.Text = "131";
             this.boxAttackNeg.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.toolTip.SetToolTip(this.boxAttackNeg, "Enter the values for Attack Stats you want to search for, \r\nwhen the legendary ha" +
-        "s a negative nature.");
             // 
             // boxAttackNeut
             // 
@@ -1240,8 +1199,6 @@ namespace AutoDA
             this.boxAttackNeut.TabIndex = 18;
             this.boxAttackNeut.Text = "146";
             this.boxAttackNeut.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.toolTip.SetToolTip(this.boxAttackNeut, "Enter the values for Attack Stats you want to search for, \r\nwhen the legendary ha" +
-        "s a neutral nature.");
             // 
             // boxAttackPos
             // 
@@ -1254,8 +1211,6 @@ namespace AutoDA
             this.boxAttackPos.TabIndex = 17;
             this.boxAttackPos.Text = "160";
             this.boxAttackPos.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.toolTip.SetToolTip(this.boxAttackPos, "Enter the values for Attack Stats you want to search for, \r\nwhen the legendary ha" +
-        "s a positive nature.");
             // 
             // labelAttackPos
             // 

--- a/AutoMaxLairUI - Code/AutoMaxLair.cs
+++ b/AutoMaxLairUI - Code/AutoMaxLair.cs
@@ -1,21 +1,13 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Drawing;
 using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 using System.IO;
-using AForge.Video;
 using AForge.Video.DirectShow;
-using System.Threading.Tasks;
-using IronPython.Hosting;
-using Microsoft.Scripting.Hosting;
-using System.Diagnostics;
 using Tommy;
-using System.Collections;
 using AutoMaxLair;
+using Newtonsoft.Json.Linq;
 
 namespace AutoDA
 {
@@ -84,7 +76,26 @@ namespace AutoDA
             {
                 configData = path + @"\Config.sample.toml";
             }
-            
+
+            List<string> legendaryList = new List<string>();
+            using (StreamReader reader = File.OpenText(@"data/boss_pokemon.json"))
+            {
+                string json = reader.ReadToEnd();
+                foreach (var item in JObject.Parse(json).Properties())
+                {
+                    legendaryList.Add(Utils.ConvertBossIdToBossName(item.Name));
+                }
+            }
+
+            List<string> ballList = new List<string>();
+            using (StreamReader reader = File.OpenText(@"data/balls.json"))
+            {
+                string json = reader.ReadToEnd();
+                foreach (var item in JObject.Parse(json).Properties())
+                {
+                    ballList.Add(Utils.ConvertBallIdToBallName(item.Name));
+                }
+            }
 
             using (StreamReader reader = new StreamReader(File.OpenRead(configData)))
             {
@@ -137,10 +148,16 @@ namespace AutoDA
                 boxSpeedNeg.Text = String.Join(",", arr5);
 
                 SetConfigValue(boxPokemon, Utils.ConvertBossIdToBossName(t["BOSS"]), t["BOSS"].Comment);
+                boxPokemon.Items.AddRange(legendaryList.ToArray());
+
                 SetConfigValue(boxBaseBall, Utils.ConvertBallIdToBallName(t["BASE_BALL"]), t["BASE_BALL"].Comment);
+                boxBaseBall.Items.AddRange(ballList.ToArray());
                 SetConfigValue(boxBaseBallValue, t["BASE_BALLS"], t["BASE_BALLS"].Comment);
+
                 SetConfigValue(boxLegendBall, Utils.ConvertBallIdToBallName(t["LEGENDARY_BALL"]), t["LEGENDARY_BALL"].Comment);
+                boxLegendBall.Items.AddRange(ballList.ToArray());
                 SetConfigValue(boxLegendBallValue, t["LEGENDARY_BALLS"], t["LEGENDARY_BALLS"].Comment);
+
                 SetConfigValue(boxMode, t["MODE"], t["MODE"].Comment);
                 SetConfigValue(boxComPort, t["COM_PORT"], t["COM_PORT"].Comment);
                 SetConfigValue(boxTesseract, t["TESSERACT_PATH"], t["TESSERACT_PATH"].Comment);

--- a/AutoMaxLairUI - Code/AutoMaxLair.cs
+++ b/AutoMaxLairUI - Code/AutoMaxLair.cs
@@ -419,7 +419,7 @@ namespace AutoDA
         private void btnTesseract_Click(object sender, EventArgs e)
         {
             FolderBrowserDialog fbd = new FolderBrowserDialog();
-            fbd.RootFolder = Environment.SpecialFolder.ProgramFiles;
+            fbd.SelectedPath = boxTesseract.Text;
             if (fbd.ShowDialog() == System.Windows.Forms.DialogResult.OK)
                 boxTesseract.Text = fbd.SelectedPath;
         }

--- a/AutoMaxLairUI - Code/AutoMaxLair.cs
+++ b/AutoMaxLairUI - Code/AutoMaxLair.cs
@@ -4,7 +4,7 @@ using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using System.IO;
-using AForge.Video.DirectShow;
+using VisioForge.Shared.DirectShowLib;
 using Tommy;
 using AutoMaxLair;
 using Newtonsoft.Json.Linq;
@@ -19,24 +19,9 @@ namespace AutoDA
             getConfig();
         }
 
-        FilterInfoCollection filterInfoCollection;
-
-
         private void AutoDA_Load(object sender, EventArgs e)
         {
             Initialize_Add();
-            int i = 0;
-            // Get every Video Capture device and put it into the combobox (with right order)
-            filterInfoCollection = new FilterInfoCollection(FilterCategory.VideoInputDevice);
-            foreach (FilterInfo filterInfo in filterInfoCollection)
-            {
-                boxVideoCapture.Items.Insert(i, filterInfo.Name);
-                i = i++;
-            }
-
-            boxVideoCapture.SelectedIndex = 0;
-
-            
             bool darktheme;
             darktheme = AutoMaxLair.Properties.Settings.Default.DarkTheme;
 
@@ -52,12 +37,6 @@ namespace AutoDA
                 btnSave.BackgroundImage = AutoMaxLair.Properties.Resources.Save2;
                 btnSettings.BackgroundImage = AutoMaxLair.Properties.Resources.Settings2;
             }
-
-            
-                
-            
-            boxVideoCapture.SelectedIndex = 0;
-            //Add(filterInfo.Name);
         }
 
         // Method to get the preset for the UI from the Config.toml
@@ -160,6 +139,19 @@ namespace AutoDA
 
                 SetConfigValue(boxMode, t["MODE"], t["MODE"].Comment);
                 SetConfigValue(boxComPort, t["COM_PORT"], t["COM_PORT"].Comment);
+
+                // Get every Video Capture device and put it into the combobox (with right order)
+                List<DsDevice> devices = new List<DsDevice>(DsDevice.GetDevicesOfCat(FilterCategory.VideoInputDevice));
+                foreach (var device in devices)
+                {
+                    boxVideoCapture.Items.Add(device.Name);
+                }
+                int videoIndex = t["VIDEO_INDEX"];
+                if (videoIndex < devices.Count)
+                {
+                    boxVideoCapture.Text = devices[videoIndex].Name;
+                }
+
                 SetConfigValue(boxTesseract, t["TESSERACT_PATH"], t["TESSERACT_PATH"].Comment);
                 SetConfigValue(boxVideoScale, t["advanced"]["VIDEO_SCALE"], t["advanced"]["VIDEO_SCALE"].Comment);
                 SetConfigValue(boxVideoDelay, t["advanced"]["VIDEO_EXTRA_DELAY"], t["advanced"]["VIDEO_EXTRA_DELAY"].Comment);

--- a/AutoMaxLairUI - Code/AutoMaxLair.cs
+++ b/AutoMaxLairUI - Code/AutoMaxLair.cs
@@ -136,29 +136,36 @@ namespace AutoDA
                 boxSpeedNeut.Text = String.Join(",", arr4);
                 boxSpeedNeg.Text = String.Join(",", arr5);
 
-                boxPokemon.Text = Utils.ConvertBossIdToBossName(t["BOSS"]);
-                boxBaseBall.Text = Utils.ConvertBallIdToBallName(t["BASE_BALL"]);
-                boxBaseBallValue.Text = t["BASE_BALLS"];
-                boxLegendBall.Text = Utils.ConvertBallIdToBallName(t["LEGENDARY_BALL"]);
-                boxLegendBallValue.Text = t["LEGENDARY_BALLS"];
-                boxMode.Text = t["MODE"];
-                boxComPort.Text = t["COM_PORT"];
-                boxTesseract.Text = t["TESSERACT_PATH"];
-                boxVideoScale.Text = t["advanced"]["VIDEO_SCALE"];
-                boxVideoDelay.Text = t["advanced"]["VIDEO_EXTRA_DELAY"];
-                boxBossIndex.Text = t["advanced"]["BOSS_INDEX"];
-                boxDyniteOre.Text = t["advanced"]["DYNITE_ORE"];
-                boxConsecutiveResets.Text = t["advanced"]["CONSECUTIVE_RESETS"];
-                boxMaxDynite.Text = t["advanced"]["MAXIMUM_ORE_COST"];
+                SetConfigValue(boxPokemon, Utils.ConvertBossIdToBossName(t["BOSS"]), t["BOSS"].Comment);
+                SetConfigValue(boxBaseBall, Utils.ConvertBallIdToBallName(t["BASE_BALL"]), t["BASE_BALL"].Comment);
+                SetConfigValue(boxBaseBallValue, t["BASE_BALLS"], t["BASE_BALLS"].Comment);
+                SetConfigValue(boxLegendBall, Utils.ConvertBallIdToBallName(t["LEGENDARY_BALL"]), t["LEGENDARY_BALL"].Comment);
+                SetConfigValue(boxLegendBallValue, t["LEGENDARY_BALLS"], t["LEGENDARY_BALLS"].Comment);
+                SetConfigValue(boxMode, t["MODE"], t["MODE"].Comment);
+                SetConfigValue(boxComPort, t["COM_PORT"], t["COM_PORT"].Comment);
+                SetConfigValue(boxTesseract, t["TESSERACT_PATH"], t["TESSERACT_PATH"].Comment);
+                SetConfigValue(boxVideoScale, t["advanced"]["VIDEO_SCALE"], t["advanced"]["VIDEO_SCALE"].Comment);
+                SetConfigValue(boxVideoDelay, t["advanced"]["VIDEO_EXTRA_DELAY"], t["advanced"]["VIDEO_EXTRA_DELAY"].Comment);
+                SetConfigValue(boxBossIndex, t["advanced"]["BOSS_INDEX"], t["advanced"]["BOSS_INDEX"].Comment);
+                SetConfigValue(boxDyniteOre, t["advanced"]["DYNITE_ORE"], t["advanced"]["DYNITE_ORE"].Comment);
+                SetConfigValue(boxConsecutiveResets, t["advanced"]["CONSECUTIVE_RESETS"], t["advanced"]["CONSECUTIVE_RESETS"].Comment);
+                SetConfigValue(boxMaxDynite, t["advanced"]["MAXIMUM_ORE_COST"], t["advanced"]["MAXIMUM_ORE_COST"].Comment);
+
                 checkBoxDebugLogs.Checked = t["advanced"]["ENABLE_DEBUG_LOGS"];
+                this.toolTip.SetToolTip(this.checkBoxDebugLogs, t["advanced"]["ENABLE_DEBUG_LOGS"].Comment);
+
                 boxCheckAttack.Checked = t["stats"]["CHECK_ATTACK_STAT"];
+                this.toolTip.SetToolTip(this.boxCheckAttack, t["CHECK_ATTACK_STAT"].Comment);
+
                 boxCheckSpeed.Checked = t["stats"]["CHECK_SPEED_STAT"];
-                boxWebhookID.Text = t["discord"]["WEBHOOK_ID"];
-                boxWebhookToken.Text = t["discord"]["WEBHOOK_TOKEN"];
-                boxUserID.Text = t["discord"]["USER_ID"];
-                boxPingName.Text = t["discord"]["USER_SHORT_NAME"];
-                boxPingSettings.Text = t["discord"]["UPDATE_LEVELS"];
-                boxGameLanguage.Text = t["language"]["LANGUAGE"]; 
+                this.toolTip.SetToolTip(this.boxCheckSpeed, t["CHECK_SPEED_STAT"].Comment);
+
+                SetConfigValue(boxWebhookID, t["discord"]["WEBHOOK_ID"], t["discord"]["WEBHOOK_ID"].Comment);
+                SetConfigValue(boxWebhookToken, t["discord"]["WEBHOOK_TOKEN"], t["discord"]["WEBHOOK_TOKEN"].Comment);
+                SetConfigValue(boxUserID, t["discord"]["USER_ID"], t["discord"]["USER_ID"].Comment);
+                SetConfigValue(boxPingName, t["discord"]["USER_SHORT_NAME"], t["discord"]["USER_SHORT_NAME"].Comment);
+                SetConfigValue(boxPingSettings, t["discord"]["UPDATE_LEVELS"], t["discord"]["UPDATE_LEVELS"].Comment);
+                SetConfigValue(boxGameLanguage, t["language"]["LANGUAGE"], t["language"]["LANGUAGE"].Comment);
             }
         }
 
@@ -596,6 +603,12 @@ namespace AutoDA
                 item.BackColor = lab;
                 item.ForeColor = textC;
             }
+        }
+
+        public void SetConfigValue(Control control, string content, string tooltip)
+        {
+            control.Text = content;
+            this.toolTip.SetToolTip(control, tooltip);
         }
     }
 

--- a/AutoMaxLairUI - Code/AutoMaxLair.csproj
+++ b/AutoMaxLairUI - Code/AutoMaxLair.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="AForge.Video" Version="2.2.5" />
     <PackageReference Include="AForge.Video.DirectShow" Version="2.2.5" />
     <PackageReference Include="IronPython" Version="2.7.11" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Tommy" Version="2.0.0" />
   </ItemGroup>
 

--- a/AutoMaxLairUI - Code/AutoMaxLair.csproj
+++ b/AutoMaxLairUI - Code/AutoMaxLair.csproj
@@ -26,11 +26,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AForge.Video" Version="2.2.5" />
-    <PackageReference Include="AForge.Video.DirectShow" Version="2.2.5" />
     <PackageReference Include="IronPython" Version="2.7.11" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Tommy" Version="2.0.0" />
+    <PackageReference Include="VisioForge.DotNet.Core.TRIAL" Version="14.0.19" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Config.sample.toml
+++ b/Config.sample.toml
@@ -506,3 +506,56 @@ TERRAIN_MISTY = "Nebel aus"
 
 # Sentence used to detect that the terrain is now psychic.
 TERRAIN_PSYCHIC = "seltsam an"
+
+#
+[Japanese]
+# Code used to select the right trained data for tesseract.
+TESSERACT_LANG_NAME = "jpn"
+
+# Code used by auto max lair to read the names in the right language.
+DATA_LANG_NAME = "ja-Hrkt"
+
+# Sentence used to detect that the bot met the backpacker.
+BACKPACKER = "バックパッカー"
+
+# Sentence used to detect that the bot met the scientist.
+SCIENTIST = "swapping"
+
+# Sentence used to detect that the bot have to choose a path in the den.
+PATH = "みちに"
+
+# Sentence used to detect that we lost a live (storm is raging).
+FAINT = "じょうくうの　あらしが"
+
+# Sentence used to detect the scientist asking us to join a DA.
+START_PHRASE = "ダイマックスアドベンチャーに"
+
+# Sentence used to detect that the weather is now normal.
+WEATHER_CLEAR = "sunlight faded|rain stopped|sandstorm subsided|hail stopped"
+
+# Sentence used to detect that the weather is now sunny.
+WEATHER_SUNLIGHT = "ひざしが"
+
+# Sentence used to detect that the weather is now rainy.
+WEATHER_RAIN = "あめが"
+
+# Sentence used to detect that the sandstorm is raging.
+WEATHER_SANDSTORM = "ふきはじめた"
+
+# Sentence used to detect that the hailstorm is raging.
+WEATHER_HAIL = "ふりはじめた"
+
+# Sentence used to detect that the terrain is now normal.
+TERRAIN_CLEAR = "electricity disappeared|grass disappeared|mist disappeared|weirdness disappeared"
+
+# Sentence used to detect that the terrain is now electrified.
+TERRAIN_ELECTRIC = "あしもとに"
+
+# Sentence used to detect that the terrain is now grassy.
+TERRAIN_GRASSY = "おいしげった"
+
+# Sentence used to detect that the terrain is now misty.
+TERRAIN_MISTY = "たちこめた"
+
+# Sentence used to detect that the terrain is now psychic.
+TERRAIN_PSYCHIC = "ふしぎなかんじ"

--- a/auto_max_lair.py
+++ b/auto_max_lair.py
@@ -356,7 +356,7 @@ def catch(ctrlr) -> str:
         and not ctrlr.check_sufficient_ore(1)
     ):
         ctrlr.log('Finishing the run without wasting a ball on the boss.')
-        ctrlr.push_buttons((b'v', 2), (b'a', 30))
+        ctrlr.push_buttons((b'v', 2), (b'a', 10))
         ctrlr.log('Congratulations!')
         return 'select_pokemon'
 

--- a/automaxlair/da_controller.py
+++ b/automaxlair/da_controller.py
@@ -403,8 +403,8 @@ class DAController(SwitchController):
                 if self.current_run.pokemon not in (None, pokemon):
                     self.log(
                         "The bot's Pokemon detected from the sprite, "
-                        f"{pokemon.name}, did not match with the previously "
-                        f"known value of {self.current_run.pokemon.name}.",
+                        f"{pokemon.name_id}, did not match with the previously "
+                        f"known value of {self.current_run.pokemon.name_id}.",
                         'WARNING'
                     )
                 self.current_run.pokemon = pokemon

--- a/automaxlair/da_controller.py
+++ b/automaxlair/da_controller.py
@@ -87,9 +87,9 @@ class DAController(SwitchController):
         self.sel_rect_5 = ((0.195, 0.11), (0.39, 0.165))
         self.type_rect_1 = ((0.24, 0.175), (0.31, 0.21))
         self.type_rect_2 = ((0.35, 0.175), (0.425, 0.21))
-        self.catch_dialogue_rect_1 = ((0.82, 0.85), (0.98, 0.88))
-        self.catch_dialogue_rect_2 = ((0.82, 0.93), (0.98, 0.96))
-        self.battle_symbol_rect = ((0.9, 0.65), (0.99, 0.77))
+        self.catch_dialogue_rect_1 = ((0.82, 0.85), (0.98, 0.86))
+        self.catch_dialogue_rect_2 = ((0.82, 0.93), (0.98, 0.94))
+        self.battle_symbol_rect = ((0.9, 0.65), (0.99, 0.79))
         self.battle_text_rect = ((0.05, 0.805), (0.95, 0.95))
         self.dmax_symbol_rect = ((0.58, 0.805), (0.61, 0.84))
         # In-den rectangles.

--- a/automaxlair/switch_controller.py
+++ b/automaxlair/switch_controller.py
@@ -271,7 +271,7 @@ class SwitchController:
         cropped_area = img[round(rect[0][1] * h):round(rect[1][1] * h),
                            round(rect[0][0] * w):round(rect[1][0] * w)]
         measured_value = self.get_rect_HSV_value(
-            cropped_area, lower_threshold, upper_threshold)
+            cropped_area, lower_threshold, upper_threshold, True)
 
         # Return True if the mean value is above the supplied threshold
         return measured_value > mean_value_threshold


### PR DESCRIPTION
Lot of smalls fixs this time, to the UI mainly but also to the python files

- Fix a crash while printing a warning
- The UI now use the comments from the config file to generate the tooltip (instead of hardcoding them)
- The path selector now start in the provided path
- Add a draft for the japanese translation (thanks Ryder and MaruBatsu)
- The UI now read the ball list and pokemon list from the json files (instead of hardcoding them)
- Shorten the skip catch sequence while using ball saver (no need to catch so the wait was far too long)
- The camera picker from the UI is now fixed (the order was alphabetic and not based on index. Also the camera picked by default is the one corresponding to the index in the config file)

The windows exe is available here if people want to test the changes
https://github.com/pifopi/AutoMaxLair/actions/runs/670834640