### PR TITLE
Improved find path

### DIFF
--- a/Config.sample.toml
+++ b/Config.sample.toml
@@ -62,7 +62,7 @@ LEGENDARY_BALLS = 500
 #       It can be used alongside KEEP PATH to find a winning path. It's up to the user to 
 #       check if the path was good or not.
 MODE = "STRONG BOSS"
-KEEP PATH WINS = "1"
+FIND PATH WINS = "1"
 
 # === COM_PORT ===
 # The COM Port is how your system internally connects to your Serial connection.

--- a/Config.sample.toml
+++ b/Config.sample.toml
@@ -62,7 +62,7 @@ LEGENDARY_BALLS = 500
 #       It can be used alongside KEEP PATH to find a winning path. It's up to the user to 
 #       check if the path was good or not.
 MODE = "STRONG BOSS"
-FIND PATH WINS = "1"
+FIND_PATH_WINS = 1
 
 # === COM_PORT ===
 # The COM Port is how your system internally connects to your Serial connection.

--- a/Config.sample.toml
+++ b/Config.sample.toml
@@ -57,8 +57,9 @@ LEGENDARY_BALLS = 500
 #   "KEEP PATH" - Will force the game to always reset on a pre-saved path.
 #       Similar to "BALL SAVER" and "STRONG BOSS" but will always use the same path if it fails.
 #       This will deplete your Ore quickly.
-#   "FIND PATH" - Will run like STRONG BOSS mode but will stop when it consecutively wins the number of 
-#       times inputted into "FIND PATH WINS".
+#   "FIND PATH" - Will run like STRONG BOSS mode but will stop when it consecutively wins the
+#       number of times inputted into "FIND PATH WINS". It is recommended to leave the 
+#       NON_LEGEND setting as "default" to avoid any false posistives.
 #       It can be used alongside KEEP PATH to find a winning path. Don't forget to update the  
 #       CONSECUTIVE_RESETS section below, before starting KEEP PATH.
 #       It's up to the user to check if the path found was good or not.

--- a/Config.sample.toml
+++ b/Config.sample.toml
@@ -57,10 +57,12 @@ LEGENDARY_BALLS = 500
 #   "KEEP PATH" - Will force the game to always reset on a pre-saved path.
 #       Similar to "BALL SAVER" and "STRONG BOSS" but will always use the same path if it fails.
 #       This will deplete your Ore quickly.
-#   "FIND PATH" - Will run like default mode but will stop as soon as it win once. It can be used
-#       alongside KEEP PATH to find a winning path. It's up  to the user to check if the path was
-#       good or not.
+#   "FIND PATH" - Will run like default mode but will stop when it consecutively wins the number of 
+#       times inputted into "FIND PATH WINS".
+#       It can be used alongside KEEP PATH to find a winning path. It's up to the user to 
+#       check if the path was good or not.
 MODE = "STRONG BOSS"
+KEEP PATH WINS = "1"
 
 # === COM_PORT ===
 # The COM Port is how your system internally connects to your Serial connection.

--- a/Config.sample.toml
+++ b/Config.sample.toml
@@ -57,7 +57,7 @@ LEGENDARY_BALLS = 500
 #   "KEEP PATH" - Will force the game to always reset on a pre-saved path.
 #       Similar to "BALL SAVER" and "STRONG BOSS" but will always use the same path if it fails.
 #       This will deplete your Ore quickly.
-#   "FIND PATH" - Will run like default mode but will stop when it consecutively wins the number of 
+#   "FIND PATH" - Will run like STRONG BOSS mode but will stop when it consecutively wins the number of 
 #       times inputted into "FIND PATH WINS".
 #       It can be used alongside KEEP PATH to find a winning path. Don't forget to update the  
 #       CONSECUTIVE WINS section below, before starting KEEP PATH.

--- a/Config.sample.toml
+++ b/Config.sample.toml
@@ -60,7 +60,7 @@ LEGENDARY_BALLS = 500
 #   "FIND PATH" - Will run like STRONG BOSS mode but will stop when it consecutively wins the number of 
 #       times inputted into "FIND PATH WINS".
 #       It can be used alongside KEEP PATH to find a winning path. Don't forget to update the  
-#       CONSECUTIVE WINS section below, before starting KEEP PATH.
+#       CONSECUTIVE_RESETS section below, before starting KEEP PATH.
 #       It's up to the user to check if the path found was good or not.
 MODE = "STRONG BOSS"
 FIND_PATH_WINS = 1

--- a/Config.sample.toml
+++ b/Config.sample.toml
@@ -59,8 +59,9 @@ LEGENDARY_BALLS = 500
 #       This will deplete your Ore quickly.
 #   "FIND PATH" - Will run like default mode but will stop when it consecutively wins the number of 
 #       times inputted into "FIND PATH WINS".
-#       It can be used alongside KEEP PATH to find a winning path. It's up to the user to 
-#       check if the path was good or not.
+#       It can be used alongside KEEP PATH to find a winning path. Don't forget to update the  
+#       CONSECUTIVE WINS section below, before starting KEEP PATH.
+#       It's up to the user to check if the path found was good or not.
 MODE = "STRONG BOSS"
 FIND_PATH_WINS = 1
 

--- a/auto_max_lair.py
+++ b/auto_max_lair.py
@@ -594,8 +594,8 @@ def select_pokemon(ctrlr) -> str:
         ctrlr.mode == 'find path' and ctrlr.consecutive_resets == FIND_PATH_WINS -1:
         ctrlr.display_results(screenshot=True)
         ctrlr.send_discord_message(
-            False,
-            f"This path won {FIND_PATH_WINS} times against {ctrlr.boss} with {run.lives} remaining."
+            True,
+            f"This path won {FIND_PATH_WINS} times against {ctrlr.boss} with {run.lives} remaining.",
             path_to_picture=f'logs/{ctrlr.log_name}_cap_'
             f'{ctrlr.num_saved_images}.png',
             embed_fields=ctrlr.get_stats_for_discord(),

--- a/auto_max_lair.py
+++ b/auto_max_lair.py
@@ -594,8 +594,8 @@ def select_pokemon(ctrlr) -> str:
         ctrlr.mode == 'find path' and ctrlr.consecutive_resets == FIND_PATH_WINS -1:
         ctrlr.display_results(screenshot=True)
         ctrlr.send_discord_message(
-            f"This path won {FIND_PATH_WINS} times against  {ctrlr.boss} "
-            "with {run.lives} remaining.",
+            False,
+            f"This path won {FIND_PATH_WINS} times against {ctrlr.boss} with {run.lives} remaining."
             path_to_picture=f'logs/{ctrlr.log_name}_cap_'
             f'{ctrlr.num_saved_images}.png',
             embed_fields=ctrlr.get_stats_for_discord(),
@@ -716,10 +716,8 @@ def select_pokemon(ctrlr) -> str:
         else:
             ctrlr.push_buttons((b'b', 3), (b'b', 1))
         ctrlr.record_ore_reward()
-        ctrlr.consecutive_resets = 0
     else:
         ctrlr.log('Resetting the game to preserve a winning seed.')
-        ctrlr.consecutive_resets += 1
         ctrlr.record_game_reset()
         # The original button sequence was added with the help of users fawress
         # and Miguel90 on the Pokemon Automation Discord.

--- a/auto_max_lair.py
+++ b/auto_max_lair.py
@@ -594,12 +594,11 @@ def select_pokemon(ctrlr) -> str:
         ctrlr.mode == 'find path' and ctrlr.consecutive_resets == FIND_PATH_WINS -1:
         ctrlr.display_results(screenshot=True)
         ctrlr.send_discord_message(
-            True,
             f"This path won {FIND_PATH_WINS} times against {ctrlr.boss} with {run.lives} remaining.",
             path_to_picture=f'logs/{ctrlr.log_name}_cap_'
             f'{ctrlr.num_saved_images}.png',
             embed_fields=ctrlr.get_stats_for_discord(),
-            level="update"
+            level="critical"
         )
         ctrlr.log(f'This path won {FIND_PATH_WINS} times with {run.lives} lives remaining.')
         return None  # Return None to signal the program to end.

--- a/auto_max_lair.py
+++ b/auto_max_lair.py
@@ -594,7 +594,7 @@ def select_pokemon(ctrlr) -> str:
         ctrlr.mode == 'find path' and ctrlr.consecutive_resets == FIND_PATH_WINS - 1):
         ctrlr.display_results(screenshot=True)
         ctrlr.send_discord_message(
-            f"This path won {FIND_PATH_WINS} times against {ctrlr.boss} with {run.lives} remaining.",
+            f"This path won {FIND_PATH_WINS} times against {ctrlr.boss} with {run.lives} lives remaining.",
             path_to_picture=f'logs/{ctrlr.log_name}_cap_'
             f'{ctrlr.num_saved_images}.png',
             embed_fields=ctrlr.get_stats_for_discord(),

--- a/auto_max_lair.py
+++ b/auto_max_lair.py
@@ -591,7 +591,7 @@ def select_pokemon(ctrlr) -> str:
         return 'join'
     # "find path" mode quits if the run is successful.
     elif run.num_caught == 4 and (
-        ctrlr.mode == 'find path' and ctrlr.consecutive_resets == FIND_PATH_WINS -1:
+        ctrlr.mode == 'find path' and ctrlr.consecutive_resets == FIND_PATH_WINS -1):
         ctrlr.display_results(screenshot=True)
         ctrlr.send_discord_message(
             f"This path won {FIND_PATH_WINS} times against {ctrlr.boss} with {run.lives} remaining.",

--- a/auto_max_lair.py
+++ b/auto_max_lair.py
@@ -691,7 +691,7 @@ def select_pokemon(ctrlr) -> str:
 
     if (
         not take_pokemon and (
-            ctrlr.mode == 'strong boss' or ctrlr.mode == 'keep path')
+            ctrlr.mode == 'strong boss' or ctrlr.mode == 'find path')
         and run.num_caught == 4 and ctrlr.check_sufficient_ore(1)
     ):
         reset_game = True

--- a/auto_max_lair.py
+++ b/auto_max_lair.py
@@ -591,7 +591,7 @@ def select_pokemon(ctrlr) -> str:
         return 'join'
     # "find path" mode quits if the run is successful.
     elif run.num_caught == 4 and (
-        ctrlr.mode == 'find path' and ctrlr.consecutive_resets == FIND_PATH_WINS -1):
+        ctrlr.mode == 'find path' and ctrlr.consecutive_resets == FIND_PATH_WINS - 1):
         ctrlr.display_results(screenshot=True)
         ctrlr.send_discord_message(
             f"This path won {FIND_PATH_WINS} times against {ctrlr.boss} with {run.lives} remaining.",


### PR DESCRIPTION
Updated Find path for user to specify how many consecutive wins they would like to have before the bot stops and alerts them to a potential good seed.
The code seems to work fine except the discord message failed on my attempt (did my net drop or is it a code error). I will recheck tomorrow but thought i'd post here in case I missed something.
the error
22:50:02 | INFO: Congratulations!
22:50:02 | DEBUG: Saving a screenshot to logs\cresselia_2021-03-25 22-33-00_cap_1.png
22:50:14 | ERROR: The Discord webhook failed to send: ('Connection aborted.', ConnectionResetError(10054, 'An existing connection was forcibly closed by the remote host', None, 10054, None))
22:50:14 | INFO: This path won 1 times with 3 lives remaining.